### PR TITLE
Fix bad peer dependency reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaardev/ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaardev/ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "1.14.0"
@@ -30,8 +30,8 @@
         "vite": "8.0.10"
       },
       "peerDependencies": {
-        "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vaardev/ui",
   "license": "MIT",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "repository": {
     "url": "git+https://github.com/vaar-dev/vaar-ui.git"
@@ -35,7 +35,7 @@
     "vite": "8.0.10"
   },
   "peerDependencies": {
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   }
 }


### PR DESCRIPTION
- Peer dependencies for react were still pointing to 19.2.4 instead of 19.2.5, so this fixes that.